### PR TITLE
Rename flag and limit goroutines

### DIFF
--- a/cmd/wick/main.go
+++ b/cmd/wick/main.go
@@ -84,7 +84,7 @@ var (
 	repeatCount     = call.Flag("repeat", "Call the procedure for the provided number of times.").Default("1").Int()
 	delayCall       = call.Flag("delay", "Provide the delay in milliseconds.").Default("0").Int()
 	callOptions     = call.Flag("option", "Procedure call option. (May be provided multiple times)").Short('o').StringMap()
-	parallelCall    = call.Flag("parallel", "Call the procedure parallel without waiting for the result to return. "+
+	concurrencyCall = call.Flag("concurrency", "Call the procedure concurrent N times without waiting for the result to return. "+
 		"Only effective when called with --repeat.").Default("1").Int()
 )
 
@@ -169,6 +169,6 @@ func main() {
 			logger.Fatal("repeat count must be greater than zero")
 		}
 		core.Call(session, *callProcedure, *callArgs, *callKeywordArgs, *logCallTime, *repeatCount, *delayCall,
-			*parallelCall, *callOptions)
+			*concurrencyCall, *callOptions)
 	}
 }

--- a/cmd/wick/main.go
+++ b/cmd/wick/main.go
@@ -85,7 +85,7 @@ var (
 	delayCall       = call.Flag("delay", "Provide the delay in milliseconds.").Default("0").Int()
 	callOptions     = call.Flag("option", "Procedure call option. (May be provided multiple times)").Short('o').StringMap()
 	parallelCall    = call.Flag("parallel", "Call the procedure parallel without waiting for the result to return. "+
-		"Only effective when called with --repeat.").Bool()
+		"Only effective when called with --repeat.").Default("1").Int()
 )
 
 const versionString = "0.4.0-dev"

--- a/core/main.go
+++ b/core/main.go
@@ -279,15 +279,15 @@ func actuallyCall(session *client.Client, procedure string, args []string, kwarg
 }
 
 func Call(session *client.Client, procedure string, args []string, kwargs map[string]string,
-	logCallTime bool, repeatCount int, delayCall int, parallelCall int, callOptions map[string]string) {
+	logCallTime bool, repeatCount int, delayCall int, concurrencyCall int, callOptions map[string]string) {
 
 	var startTime int64
 	if logCallTime {
 		startTime = time.Now().UnixMilli()
 	}
 
-	if parallelCall > 1 {
-		concurrentGoroutines := make(chan struct{}, parallelCall)
+	if concurrencyCall > 1 {
+		concurrentGoroutines := make(chan struct{}, concurrencyCall)
 		var wg sync.WaitGroup
 
 		for i := 0; i < repeatCount; i++ {

--- a/core/main.go
+++ b/core/main.go
@@ -279,19 +279,26 @@ func actuallyCall(session *client.Client, procedure string, args []string, kwarg
 }
 
 func Call(session *client.Client, procedure string, args []string, kwargs map[string]string,
-	logCallTime bool, repeatCount int, delayCall int, parallelCall bool, callOptions map[string]string) {
+	logCallTime bool, repeatCount int, delayCall int, parallelCall int, callOptions map[string]string) {
 
 	var startTime int64
 	if logCallTime {
 		startTime = time.Now().UnixMilli()
 	}
 
-	if parallelCall {
+	if parallelCall > 1 {
+		concurrentGoroutines := make(chan struct{}, parallelCall)
 		var wg sync.WaitGroup
-		wg.Add(repeatCount)
 
 		for i := 0; i < repeatCount; i++ {
-			go actuallyCall(session, procedure, args, kwargs, logCallTime, delayCall, &wg, callOptions)
+			wg.Add(1)
+			go func(i int) {
+				concurrentGoroutines <- struct{}{}
+
+				actuallyCall(session, procedure, args, kwargs, logCallTime, delayCall, &wg, callOptions)
+
+				<-concurrentGoroutines
+			}(i)
 		}
 
 		wg.Wait()


### PR DESCRIPTION
fixes #85 
- Rename --parallel to --concurrency
- limit goroutines(max of N goroutines run at a single point in time)