### PR TITLE
cmd/wick: core: support for exiting after receiving an event

### DIFF
--- a/cmd/wick/main.go
+++ b/cmd/wick/main.go
@@ -69,13 +69,13 @@ var (
 	logJoinTime      = join.Flag("time", "Log session join time").Bool()
 	keepaliveJoin    = join.Flag("keepalive", "interval between websocket pings.").Default("0").Int()
 
-	subscribe               = kingpin.Command("subscribe", "Subscribe a topic.")
-	subscribeTopic          = subscribe.Arg("topic", "Topic to subscribe.").Required().String()
-	subscribeOptions        = subscribe.Flag("option", "Subscribe option. (May be provided multiple times)").Short('o').StringMap()
-	subscribePrintDetails   = subscribe.Flag("details", "Print event details.").Bool()
-	subscribeExitAfterEvent = subscribe.Flag("exit", "Exit after receiving an event.").Bool()
-	logSubscribeTime        = subscribe.Flag("time", "Log time to join session and subscribe a topic.").Bool()
-	concurrentSubscribe     = subscribe.Flag("concurrency", "Subscribe to topic concurrently. "+
+	subscribe             = kingpin.Command("subscribe", "Subscribe a topic.")
+	subscribeTopic        = subscribe.Arg("topic", "Topic to subscribe.").Required().String()
+	subscribeOptions      = subscribe.Flag("option", "Subscribe option. (May be provided multiple times)").Short('o').StringMap()
+	subscribePrintDetails = subscribe.Flag("details", "Print event details.").Bool()
+	subscribeEventCount   = subscribe.Flag("event-count", "Wait for a given number of events and exit.").Default("0").Int()
+	logSubscribeTime      = subscribe.Flag("time", "Log time to join session and subscribe a topic.").Bool()
+	concurrentSubscribe   = subscribe.Flag("concurrency", "Subscribe to topic concurrently. "+
 		"Only effective when called with --parallel.").Default("1").Int()
 	subscribeSessionCount = subscribe.Flag("parallel", "Start requested number of wamp sessions").Default("1").Int()
 	keepaliveSubscribe    = subscribe.Flag("keepalive", "interval between websocket pings.").Default("0").Int()
@@ -269,7 +269,9 @@ func main() {
 		if *subscribeSessionCount < 0 {
 			log.Fatalln("parallel must be greater than zero")
 		}
-
+		if *subscribeEventCount < 0 {
+			log.Fatalln("event count must be greater than zero")
+		}
 		if *logSubscribeTime {
 			startTime = time.Now().UnixMilli()
 		}
@@ -296,7 +298,9 @@ func main() {
 			wp.StopWait()
 		}()
 
-		eventC := make(chan struct{})
+		// buffer to match the number of sessions, otherwise we'd have to
+		// drain the channel
+		eventC := make(chan struct{}, len(sessions))
 		wp := workerpool.New(*concurrentSubscribe)
 		for _, session := range sessions {
 			sess := session
@@ -310,19 +314,35 @@ func main() {
 		}
 		wp.StopWait()
 
+		// TODO find a nicer way of waiting for all sessions to complete
+		allSessionsDoneC := make(chan struct{}, 1)
+		go func() {
+			for _, session := range sessions {
+				<-session.Done()
+			}
+			log.Print("router gone")
+			allSessionsDoneC <- struct{}{}
+		}()
+
 		// Wait for CTRL-c or client close while handling events.
 		sigChan := make(chan os.Signal, 1)
 		signal.Notify(sigChan, os.Interrupt)
-		for _, session := range sessions {
+		events := 0
+		for {
 			select {
 			case <-eventC:
-				if *subscribeExitAfterEvent {
+				events++
+				if *subscribeEventCount > 0 && events == *subscribeEventCount {
+					// note this will race against session
+					// goroutines possibly trying to send to
+					// event channel but nothing is
+					// receiving from it
 					return
 				}
 			case <-sigChan:
 				return
-			case <-session.Done():
-				log.Print("Router gone, exiting")
+			case <-allSessionsDoneC:
+				return
 			}
 		}
 

--- a/core/main.go
+++ b/core/main.go
@@ -91,12 +91,15 @@ func ConnectCryptoSign(url string, realm string, serializer serialize.Serializat
 }
 
 func Subscribe(session *client.Client, topic string, subscribeOptions map[string]string,
-	printDetails bool, logSubscribeTime bool) error {
+	printDetails bool, logSubscribeTime bool, eventReceived chan struct{}) error {
 	eventHandler := func(event *wamp.Event) {
 		if printDetails {
 			argsKWArgs(event.Arguments, event.ArgumentsKw, event.Details)
 		} else {
 			argsKWArgs(event.Arguments, event.ArgumentsKw, nil)
+		}
+		if eventReceived != nil {
+			eventReceived <- struct{}{}
 		}
 	}
 


### PR DESCRIPTION
Add a `--exit` flag to `subscribe` command, such that wick will exit after receiving an event on the desired topic.